### PR TITLE
implement TFUI clientconfiguration based on env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ tfui server
 
 ### Client
 
+Environment variables available are:
+
+- `TFUI_ADDR` as location of the TFUI server (default: `http://localhost:8080`)
+- `TFUI_TOKEN` to authenticate to the API (default: not set)
+
 ```bash
 tfui is a tool to manage the Terraform UI server, e.g. upload plans, or reset the server.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tommartensen/tfui/pkg/client/plan"
 	"github.com/tommartensen/tfui/pkg/client/system"
+	"github.com/tommartensen/tfui/pkg/config"
 	"github.com/tommartensen/tfui/pkg/server"
 )
 
@@ -18,9 +19,9 @@ var rootCmd = &cobra.Command{
 }
 
 func currentConfig(cmd *cobra.Command, args []string) {
-	// TODO: implement based on env vars
-	fmt.Println("TFUI_TOKEN_ADDR=http://localhost:8080")
-	fmt.Println("TFUI_TOKEN_TOKEN=")
+	configuration := config.New()
+	fmt.Printf("Server Address: %s\n", configuration.Addr)
+	fmt.Printf("Client Token:   %s\n", configuration.ClientToken)
 }
 
 func addConfigCommands(rootCmd *cobra.Command) {

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -17,5 +17,5 @@ server:
   ingress:
     domain: tfui.local
   deploy:
-    replicas: 1
+    replicas: 2
     maxUnavailable: 1

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -17,5 +17,5 @@ server:
   ingress:
     domain: tfui.local
   deploy:
-    replicas: 2
+    replicas: 1
     maxUnavailable: 1

--- a/pkg/client/executor.go
+++ b/pkg/client/executor.go
@@ -2,13 +2,12 @@ package client
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net/http"
-)
 
-// TODO: use config for address
-// TODO: use application token from config
-var tfUiAddr = "http://localhost:8080"
+	"github.com/tommartensen/tfui/pkg/config"
+)
 
 func RequestWithoutBody(method string, url string) (*http.Request, error) {
 	return http.NewRequest(method, url, nil)
@@ -19,7 +18,8 @@ func RequestWithBody(method string, url string, body []byte) (*http.Request, err
 }
 
 func Request(method string, uri string, body []byte) (*http.Response, error) {
-	url := fmt.Sprintf("%s/api/%s", tfUiAddr, uri)
+	configuration := config.New()
+	url := fmt.Sprintf("%s/api/%s", configuration.Addr, uri)
 	var req *http.Request
 	var err error
 
@@ -31,6 +31,10 @@ func Request(method string, uri string, body []byte) (*http.Response, error) {
 	if err != nil {
 		return &http.Response{}, err
 	}
+	if len(configuration.ClientToken) > 0 {
+		b64EncodedClientToken := base64.StdEncoding.EncodeToString([]byte(configuration.ClientToken))
+		bearer := fmt.Sprintf("Bearer %s", b64EncodedClientToken)
+		req.Header.Add("Authorization", bearer)
+	}
 	return http.DefaultClient.Do(req)
-
 }

--- a/pkg/client/plan/upload.go
+++ b/pkg/client/plan/upload.go
@@ -51,8 +51,11 @@ func UploadPlan(cmd *cobra.Command, args []string) {
 	}
 
 	resp, err := client.Request(http.MethodPost, "plan", body)
+
 	if err != nil {
-		resp.Body.Close()
+		if resp != nil {
+			resp.Body.Close()
+		}
 		log.Fatalln(fmt.Errorf("plan upload failed: %v", err))
 	}
 	if resp.StatusCode != http.StatusCreated {

--- a/pkg/client/plan/upload.go
+++ b/pkg/client/plan/upload.go
@@ -21,7 +21,7 @@ func buildPlanMeta() models.TfPlanMeta {
 		Project:   os.Getenv("PROJECT"),
 		Workspace: os.Getenv("WORKSPACE"),
 		Date:      util.GetCurrentDatetime(),
-		CommitID:  util.GetCommitId(),
+		CommitID:  util.GetCommitID(),
 	}
 }
 
@@ -52,7 +52,7 @@ func UploadPlan(cmd *cobra.Command, args []string) {
 
 	resp, err := client.Request(http.MethodPost, "plan", body)
 	if err != nil {
-		// resp.Body.Close()
+		resp.Body.Close()
 		log.Fatalln(fmt.Errorf("plan upload failed: %v", err))
 	}
 	if resp.StatusCode != http.StatusCreated {

--- a/pkg/client/plan/upload.go
+++ b/pkg/client/plan/upload.go
@@ -59,8 +59,10 @@ func UploadPlan(cmd *cobra.Command, args []string) {
 		log.Fatalln(fmt.Errorf("plan upload failed: %v", err))
 	}
 	if resp.StatusCode != http.StatusCreated {
+		resp.Body.Close()
 		log.Fatalln(fmt.Errorf("plan upload failed (HTTP %d)", resp.StatusCode))
 	} else {
 		log.Println("Plan uploaded")
+		resp.Body.Close()
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,16 +3,20 @@ package config
 import "github.com/tommartensen/tfui/pkg/util"
 
 type Configuration struct {
-	ApplicationToken string
-	BaseDir          string
-	Port             string
+	ServerToken string
+	BaseDir     string
+	Port        string
+	Addr        string
+	ClientToken string
 }
 
 // Initialize the Configuration struct by reading the values for it from the environment variables.
 func New() *Configuration {
 	return &Configuration{
-		ApplicationToken: util.GetEnv("APPLICATION_TOKEN", ""),
-		BaseDir:          util.GetEnv("BASE_DIR", "./plans"),
-		Port:             util.GetEnv("PORT", "8080"),
+		ServerToken: util.GetEnv("APPLICATION_TOKEN", ""),
+		BaseDir:     util.GetEnv("BASE_DIR", "./plans"),
+		Port:        util.GetEnv("PORT", "8080"),
+		Addr:        util.GetEnv("TFUI_ADDR", "http://localhost:8080"),
+		ClientToken: util.GetEnv("TFUI_TOKEN", ""),
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewDefaultConfiguration(t *testing.T) {
 	c := config.New()
-	assert.Equal(t, c.ApplicationToken, "")
+	assert.Equal(t, c.ServerToken, "")
 	assert.Equal(t, c.BaseDir, "./plans")
 	assert.Equal(t, c.Port, "8080")
 }
@@ -25,7 +25,7 @@ func TestConfigurationWithEnvironment(t *testing.T) {
 	defer os.Unsetenv("PORT")
 
 	c := config.New()
-	assert.Equal(t, c.ApplicationToken, "testtoken")
+	assert.Equal(t, c.ServerToken, "testtoken")
 	assert.Equal(t, c.BaseDir, "./test/plans")
 	assert.Equal(t, c.Port, "4000")
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -31,14 +31,14 @@ func authenticateRequest(r *http.Request) error {
 	}
 
 	cfg := config.New()
-	if string(token) != cfg.ApplicationToken {
+	if string(token) != cfg.ServerToken {
 		return errors.New("secret mismatch")
 	}
 	return nil
 }
 
 func logRequest(r *http.Request) {
-	log.Printf("Received call [%s] %s\n", r.Method, strings.Replace(r.URL.Path, "\n", "", -1))
+	log.Printf("Received call [%s] %s\n", r.Method, strings.ReplaceAll(r.URL.Path, "\n", ""))
 }
 
 // Middleware function called for each request

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,7 +40,7 @@ func (a *Server) Initialize() {
 	api.HandleFunc("/plan/summary/by-params", handler.GetPlanSummary).
 		Methods("GET").
 		Queries("region", "{region}", "project", "{project}", "workspace", "{workspace}")
-	if len(a.Config.ApplicationToken) > 0 {
+	if len(a.Config.ServerToken) > 0 {
 		api.Use(middleware.Middleware)
 	}
 	a.Router.PathPrefix("/").Handler(http.FileServer(http.Dir("./dist")))

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -48,7 +48,7 @@ func GetCurrentDatetime() string {
 	return currentTime.Format("2006-01-02 15:04:05")
 }
 
-func GetCommitId() string {
+func GetCommitID() string {
 	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Closes #6 .

Adding two env vars for the client:

- `TFUI_ADDR` as location of the TFUI server (default: `http://localhost:8080`)
- `TFUI_TOKEN` to authenticate to the API (default: not set)